### PR TITLE
feat: 新增 Client 私訊震動視窗事件接收與控制

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -75,6 +75,7 @@ enum SocketClientEvent {
   // Message
   SEND_MESSAGE = 'message',
   SEND_DIRECT_MESSAGE = 'directMessage',
+  SEND_SHAKE_WINDOW = 'shakeWindow',
   // RTC
   RTC_OFFER = 'RTCOffer',
   RTC_ANSWER = 'RTCAnswer',
@@ -128,6 +129,7 @@ enum SocketServerEvent {
   // Message
   ON_MESSAGE = 'onMessage',
   ON_DIRECT_MESSAGE = 'onDirectMessage',
+  ON_SHAKE_WINDOW = 'onShakeWindow',
   // RTC
   RTC_OFFER = 'RTCOffer',
   RTC_ANSWER = 'RTCAnswer',
@@ -454,6 +456,48 @@ function connectSocket(token: string): Socket | null {
         // if (!userId && args[0] && args[0].userId) {
         //   userId = args[0].userId;
         // }
+
+        // shakeDirectMessage unique handling
+        if (event === SocketServerEvent.ON_SHAKE_WINDOW) {
+          const {
+            userId: fromUserId,
+            targetId: toUserId,
+            targetName: fromUserName,
+          } = args[0];
+
+          // check data validity
+          if (!fromUserId || !toUserId || !fromUserName) {
+            console.error('無效的抖動消息數據');
+            return;
+          }
+
+          // generate window key
+          const windowId = `directMessage_${fromUserId}`;
+
+          // check if direct message popup window exists
+          if (popups[windowId] && !popups[windowId].isDestroyed()) {
+            // is exists, set always on top to set top and cancel to avoid top-locked
+            popups[windowId].setAlwaysOnTop(true);
+            popups[windowId].setAlwaysOnTop(false);
+            popups[windowId].focus();
+          } else {
+            // not exists, create new direct message popup window
+            createPopup('directMessage', windowId, 600, 800).then((window) => {
+              if (!window) return;
+
+              ipcMain.on('request-initial-data', (_, to) => {
+                if (to === windowId) {
+                  window.webContents.send('response-initial-data', windowId, {
+                    userId: toUserId,
+                    targetId: fromUserId,
+                    targetName: fromUserName,
+                  });
+                }
+              });
+            });
+          }
+        }
+
         console.log('socket.on', event, ...args);
         BrowserWindow.getAllWindows().forEach((window) => {
           window.webContents.send(event, ...args);
@@ -712,15 +756,15 @@ app.on('ready', async () => {
   });
 
   // Initial data request handlers
-  ipcMain.on('request-initial-data', (_, to) => {
+  ipcMain.on('request-initial-data', (_, from) => {
     BrowserWindow.getAllWindows().forEach((window) => {
-      window.webContents.send('request-initial-data', to);
+      window.webContents.send('request-initial-data', from);
     });
   });
 
-  ipcMain.on('response-initial-data', (_, from, data) => {
+  ipcMain.on('response-initial-data', (_, to, data) => {
     BrowserWindow.getAllWindows().forEach((window) => {
-      window.webContents.send('response-initial-data', from, data);
+      window.webContents.send('response-initial-data', to, data);
     });
   });
 

--- a/main.ts
+++ b/main.ts
@@ -485,6 +485,15 @@ function connectSocket(token: string): Socket | null {
             createPopup('directMessage', windowId, 600, 800).then((window) => {
               if (!window) return;
 
+              window.setAlwaysOnTop(true);
+              window.setAlwaysOnTop(false);
+              window.focus();
+
+              window.webContents.send(
+                SocketServerEvent.ON_SHAKE_WINDOW,
+                ...args,
+              );
+
               ipcMain.on('request-initial-data', (_, to) => {
                 if (to === windowId) {
                   window.webContents.send('response-initial-data', windowId, {

--- a/src/components/popups/DirectMessage.tsx
+++ b/src/components/popups/DirectMessage.tsx
@@ -80,7 +80,7 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
 
     const handleSendShakeWindow = () => {
       if (!socket || cooldownRef.current > 0) return;
-      socket.send.shakeDirectMessage({ userId, targetId });
+      socket.send.shakeWindow({ userId, targetId });
       cooldownRef.current = SHAKE_COOLDOWN;
 
       // debounce
@@ -99,7 +99,11 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
       return () => clearInterval(timer);
     };
 
-    const handleReceiveShake = (data: any) => {
+    const handleReceiveShake = (data: {
+      userId: User['userId'];
+      targetId: User['userId'];
+      targetName: User['name'];
+    }) => {
       // check if the current conversation
       const { userId: senderId, targetId: receiverId } = data;
       if (senderId && receiverId && userId === receiverId) {
@@ -148,7 +152,7 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
 
       const eventHandlers = {
         [SocketServerEvent.ON_DIRECT_MESSAGE]: handleOnDirectMessage,
-        [SocketServerEvent.SHAKE_DIRECT_MESSAGE]: handleReceiveShake,
+        [SocketServerEvent.ON_SHAKE_WINDOW]: handleReceiveShake,
       };
       const unsubscribe: (() => void)[] = [];
 

--- a/src/components/popups/DirectMessage.tsx
+++ b/src/components/popups/DirectMessage.tsx
@@ -30,6 +30,8 @@ interface DirectMessagePopupProps {
   windowRef: React.RefObject<HTMLDivElement>;
 }
 
+const SHAKE_COOLDOWN = 3000;
+
 const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
   (initialData: DirectMessagePopupProps) => {
     // Hooks
@@ -38,6 +40,7 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
 
     // Refs
     const refreshRef = useRef(false);
+    const cooldownRef = useRef(0);
 
     // States
     const [user, setUser] = useState<User>(createDefault.user());
@@ -73,6 +76,35 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
     ) => {
       if (!socket) return;
       socket.send.directMessage({ directMessage, userId, targetId });
+    };
+
+    const handleSendShakeWindow = () => {
+      if (!socket || cooldownRef.current > 0) return;
+      socket.send.shakeDirectMessage({ userId, targetId });
+      cooldownRef.current = SHAKE_COOLDOWN;
+
+      // debounce
+      const startTime = Date.now();
+      const timer = setInterval(() => {
+        const elapsed = Date.now() - startTime;
+        const remaining = Math.max(0, SHAKE_COOLDOWN - elapsed);
+
+        if (remaining === 0) {
+          clearInterval(timer);
+        }
+
+        cooldownRef.current = remaining;
+      }, 100);
+
+      return () => clearInterval(timer);
+    };
+
+    const handleReceiveShake = (data: any) => {
+      // check if the current conversation
+      const { userId: senderId, targetId: receiverId } = data;
+      if (senderId && receiverId && userId === receiverId) {
+        handleShakeWindow();
+      }
     };
 
     const handleOnDirectMessage = (data: DirectMessage) => {
@@ -116,6 +148,7 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
 
       const eventHandlers = {
         [SocketServerEvent.ON_DIRECT_MESSAGE]: handleOnDirectMessage,
+        [SocketServerEvent.SHAKE_DIRECT_MESSAGE]: handleReceiveShake,
       };
       const unsubscribe: (() => void)[] = [];
 
@@ -237,7 +270,7 @@ const DirectMessagePopup: React.FC<DirectMessagePopupProps> = React.memo(
                   />
                   <div
                     className={`${directMessage['button']} ${directMessage['nudge']}`}
-                    onClick={() => handleShakeWindow()}
+                    onClick={() => handleSendShakeWindow()}
                   />
                 </div>
                 <div className={directMessage['buttons']}>

--- a/src/services/ipc.service.ts
+++ b/src/services/ipc.service.ts
@@ -59,26 +59,26 @@ const ipcService = {
 
   // Initial data methods
   initialData: {
-    request: (to: string, callback: (data: any) => void) => {
+    request: (id: string, callback: (data: any) => void) => {
       if (isElectron) {
-        ipcRenderer.send('request-initial-data', to);
+        ipcRenderer.send('request-initial-data', id);
         ipcRenderer.on(
           'response-initial-data',
-          (_: any, from: string, data: any) => {
-            if (from != to) return;
-            callback(data);
+          (_: any, to: string, data: any) => {
+            if (to != id) return;
             ipcRenderer.removeAllListeners('response-initial-data');
+            callback(data);
           },
         );
       } else {
         console.warn('IPC not available - not in Electron environment');
       }
     },
-    onRequest: (host: string, data: any, callback?: () => void) => {
+    onRequest: (id: string, data: any, callback?: () => void) => {
       if (isElectron) {
-        ipcRenderer.on('request-initial-data', (_: any, to: string) => {
-          if (to != host) return;
-          ipcRenderer.send('response-initial-data', host, data);
+        ipcRenderer.on('request-initial-data', (_: any, from: string) => {
+          if (from != id) return;
+          ipcRenderer.send('response-initial-data', id, data);
           ipcRenderer.removeAllListeners('request-initial-data');
           if (callback) callback();
         });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -667,6 +667,7 @@ export enum SocketClientEvent {
   // Message
   SEND_MESSAGE = 'message',
   SEND_DIRECT_MESSAGE = 'directMessage',
+  SEND_SHAKE_WINDOW = 'shakeWindow',
   // RTC
   RTC_OFFER = 'RTCOffer',
   RTC_ANSWER = 'RTCAnswer',
@@ -674,7 +675,6 @@ export enum SocketClientEvent {
   // Echo
   PING = 'ping',
   // Direct Message Shake
-  SHAKE_DIRECT_MESSAGE = 'shakeDirectMessage',
 }
 
 export enum SocketServerEvent {
@@ -722,6 +722,7 @@ export enum SocketServerEvent {
   // Message
   ON_MESSAGE = 'onMessage',
   ON_DIRECT_MESSAGE = 'onDirectMessage',
+  ON_SHAKE_WINDOW = 'onShakeWindow',
   // RTC
   RTC_OFFER = 'RTCOffer',
   RTC_ANSWER = 'RTCAnswer',
@@ -739,7 +740,6 @@ export enum SocketServerEvent {
   // Popup
   OPEN_POPUP = 'openPopup',
   // Direct Message Shake
-  SHAKE_DIRECT_MESSAGE = 'shakeDirectMessage',
 }
 
 export enum PopupType {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -673,6 +673,8 @@ export enum SocketClientEvent {
   RTC_ICE_CANDIDATE = 'RTCIceCandidate',
   // Echo
   PING = 'ping',
+  // Direct Message Shake
+  SHAKE_DIRECT_MESSAGE = 'shakeDirectMessage',
 }
 
 export enum SocketServerEvent {
@@ -736,6 +738,8 @@ export enum SocketServerEvent {
   RECONNECT_ERROR = 'reconnect_error',
   // Popup
   OPEN_POPUP = 'openPopup',
+  // Direct Message Shake
+  SHAKE_DIRECT_MESSAGE = 'shakeDirectMessage',
 }
 
 export enum PopupType {


### PR DESCRIPTION
### 🧩 Client or Server
Client

### ✨ 變動概述
1. socket事件新增私訊震動
2. 私訊面板新增震動發送與接收事件

### 🔧 是否需要更新伺服器
是，伺服器需要支援接收與發送 `shakeDirectMessage` 事件

### 📎 補充說明
目前震動相關警告訊息的表現並未實作於私訊聊天室中，而是以 `Error Popup` 的形式呈現。