### PR TITLE
feat: 新增頻道用戶拖曳與調整版面

### DIFF
--- a/src/styles/pages/server.module.css
+++ b/src/styles/pages/server.module.css
@@ -341,8 +341,11 @@
   color: #555;
 }
 
-.channelList .channelList:not(.lobby) .channelTab,
-.channelList .channelList:not(.lobby) .userTab {
+.channelList .channelList:not(.lobby) .channelTab {
+  padding-left: 25px;
+}
+
+.channelList .userList {
   padding-left: 25px;
 }
 
@@ -366,7 +369,7 @@
   display: flex;
   align-items: center;
   height: 1.8rem;
-  padding: 1px 20px 1px 8px;
+  padding: 1px 20px 1px 0px;
   cursor: pointer;
   gap: 5px;
 }

--- a/src/styles/popups/editProfile.module.css
+++ b/src/styles/popups/editProfile.module.css
@@ -433,6 +433,25 @@
   background-image: url('../../../public/im/avatar_border.png');
   background-repeat: no-repeat;
   background-position: 0 0;
+  z-index: 1;
+}
+
+.userProfile .avatar.editable::before {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  right: -8px;
+  width: 15px;
+  height: 15px;
+  background-color: white;
+  background-image: url('../../../public/im/btn-edit.png');
+  background-size: 70% 70%;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: 4px;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.2);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .userProfile .userName {


### PR DESCRIPTION
🧩 Client or Server
Client

✨ 變動概述
1. 新增頻道用戶拖曳功能，語音群頁面中群管理員可以拖動除自己以外用戶至任何頻道
2. 頻道用戶位置統一對齊至二級頻道
3. 新增個人檔案編輯模式下上傳提示圖示

🔧 是否需要更新伺服器
否

📎 補充說明
無