### PR TITLE
Feature: Automatic change software language on first open

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ NEXT_PUBLIC_WS_URL=https://localhost:4500 # If your server is on the same machin
 
 # Crowdin Settings (Optional)
 NEXT_PUBLIC_CROWDIN_DISTRIBUTION_HASH= # If not provided, will use local files (./public/locales/[lang]/[ns]) instead
+
+# Language Auto-detection Settings (Optional)
+NEXT_PUBLIC_FREE_IP_API_URL=put_the_api_url_here # If not provided, will use fallback language instead

--- a/main.ts
+++ b/main.ts
@@ -1085,10 +1085,6 @@ app.on('ready', async () => {
     event.reply('receive-channel-message-sound', store.get('receiveChannelMessageSound') ?? true);
   });
 
-  ipcMain.on('get-system-locale', (event) => {
-    event.reply('system-locale', { primary: app.getLocale(), all: app.getPreferredSystemLanguages() });
-  });
-
   // Basic
   ipcMain.on('set-auto-launch', (_, enable) => {
     setAutoLaunch(enable);

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -9,10 +9,12 @@ import MainTabProvider from '@/providers/MainTab';
 import ThemeProvider from '@/providers/Theme';
 import LoadingProvider from '@/providers/Loading';
 import SoundPlayerProvider from '@/providers/SoundPlayer';
-import i18n, { LanguageKey } from '@/i18n';
 
 // services
 import ipcService from '@/services/ipc.service';
+
+// utilities
+import { setupLanguage } from '@/utils/language';
 
 interface ProvidersProps {
   children: React.ReactNode;
@@ -20,8 +22,7 @@ interface ProvidersProps {
 
 const Providers = ({ children }: ProvidersProps) => {
   useEffect(() => {
-    const language = localStorage.getItem('language') as LanguageKey;
-    if (language) i18n.changeLanguage(language);
+    setupLanguage();
   }, []);
 
   useEffect(() => {

--- a/src/components/pages/Login.tsx
+++ b/src/components/pages/Login.tsx
@@ -110,10 +110,6 @@ const LoginPage: React.FC<LoginPageProps> = React.memo(({ setSection }) => {
   }, [accounts]);
 
   useEffect(() => {
-    ipcService.systemLocale.setup();
-  }, []);
-
-  useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (!comboRef.current?.contains(e.target as Node)) setShowAccountselectBox(false);
     };

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,17 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 export type LanguageKey = 'zh-TW' | 'zh-CN' | 'en' | 'ja' | 'fa' | 'pt-BR' | 'ru' | 'es-ES';
+export const LANGUAGES: { code: LanguageKey }[] = [
+  { code: 'zh-TW'},
+  { code: 'zh-CN'},
+  { code: 'en'},
+  { code: 'ru'},
+  { code: 'pt-BR'},
+  { code: 'ja'},
+  { code: 'es-ES'},
+  { code: 'fa' },
+];
+
 
 import otaClient from '@crowdin/ota-client';
 import i18next from 'i18next';

--- a/src/services/ipc.service.ts
+++ b/src/services/ipc.service.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import i18n from '@/i18n';
 import { DiscordPresence, PopupType, SocketClientEvent, SocketServerEvent, speakingMode, mixMode } from '@/types';
 
 // Safe reference to electron's ipcRenderer
@@ -920,22 +919,6 @@ const ipcService = {
         });
         return () => ipcRenderer.removeAllListeners('receive-channel-message-sound');
       },
-    },
-  },
-
-  systemLocale: {
-    setup: () => {
-      if (localStorage.getItem('language')) return;
-      if (!isElectron) {
-        i18n.changeLanguage(navigator.language);
-        localStorage.setItem('language', navigator.language || 'zh-TW');
-        return;
-      }
-      ipcRenderer.send('get-system-locale');
-      ipcRenderer.once('system-locale', (_: any, locale: { primary: string; all: string[] }) => {
-        i18n.changeLanguage(locale.primary);
-        localStorage.setItem('language', locale.primary || 'zh-TW');
-      });
     },
   },
 };

--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -79,7 +79,7 @@ export const getLangByIp = async (): Promise<LanguageKey> => {
 
   const data = await response.json();
 
-  let lang: string | undefined = data.languages?.[0];
+  const lang: string | undefined = data.languages?.[0];
   if (!lang) return 'en';
 
   const match = LANGUAGES.find(({ code }) => code.includes(lang));
@@ -92,4 +92,4 @@ export const setupLanguage = async () => {
   const language = localStorage.getItem('language') || (await getLangByIp());
   localStorage.setItem('language', language);
   i18n.changeLanguage(language);
-}
+};

--- a/src/utils/language.ts
+++ b/src/utils/language.ts
@@ -1,8 +1,10 @@
 import { TFunction } from 'i18next';
-import i18n from '@/i18n';
+import i18n, { LanguageKey, LANGUAGES } from '@/i18n';
 
 // Types
 import { Permission } from '@/types';
+
+const FREE_IP_API_URL = process.env.NEXT_PUBLIC_FREE_IP_API_URL;
 
 export const getPermissionText = (t: TFunction<'translation', undefined>, permission: number): string => {
   const permissionMap: Record<number, string> = {
@@ -70,3 +72,24 @@ export const getFormatTimestamp = (t: TFunction<'translation', undefined>, times
   }
   return `${messageDate.toLocaleDateString(timezoneLang)} ${timeString}`;
 };
+
+export const getLangByIp = async (): Promise<LanguageKey> => {
+  const response = await fetch(`${FREE_IP_API_URL}/json`);
+  if (!response.ok) return 'en';
+
+  const data = await response.json();
+
+  let lang: string | undefined = data.languages?.[0];
+  if (!lang) return 'en';
+
+  const match = LANGUAGES.find(({ code }) => code.includes(lang));
+  if (!match) return 'en';
+
+  return match.code;
+};
+
+export const setupLanguage = async () => {
+  const language = localStorage.getItem('language') || (await getLangByIp());
+  localStorage.setItem('language', language);
+  i18n.changeLanguage(language);
+}


### PR DESCRIPTION
**[KD Task](https://kd.ricecall.com/p/board/RiceCall-App?task=Automatic-Language-Detection)**

This Pull Requests adds the funcionality of automatic language detection by IP, changing the app language when it first opens, using[ Free IP API](https://freeipapi.com/). This API returns, among other data, the official country's language codes based on ISO 639. The first code is then searched through the avaible translations and if none is found, the default language (English) is kept being displayed.

Note: This API has a rate limit of 60 requests per minute when using for free and CAN be used for commercial and non commercial purposes.

For testing, the following environment variable needs to be defined:
`NEXT_PUBLIC_FREE_IP_API_URL=https://free.freeipapi.com/api`